### PR TITLE
Demonstrate the correct way to send a welcome message in 1:1

### DIFF
--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -5,6 +5,7 @@ import { SetLocaleFromTeamsSetting } from "./middleware/SetLocaleFromTeamsSettin
 import { StripBotAtMentions } from "./middleware/StripBotAtMentions";
 // import { SetAADObjectId } from "./middleware/SetAADObjectId";
 import { LoadBotChannelData } from "./middleware/LoadBotChannelData";
+import { ResetBotChat } from "./middleware/ResetBotChat";
 import { Strings } from "./locale/locale";
 import { loadSessionAsync } from "./utils/DialogUtils";
 import * as teams from "botbuilder-teams";
@@ -36,6 +37,7 @@ export class Bot extends builder.UniversalBot {
             new SetLocaleFromTeamsSetting(),
 
             // set on "botbuilder" (after session created)
+            new ResetBotChat(this),
             new StripBotAtMentions(),
             // new SetAADObjectId(),
             new LoadBotChannelData(this.get("channelStorage")),
@@ -92,14 +94,41 @@ export class Bot extends builder.UniversalBot {
     }
 
     // set incoming event to any because membersAdded is not a field in builder.IEvent
-    private getConversationUpdateHandler(bot: builder.UniversalBot): (event: any) => void {
-        return async function(event: any): Promise<void> {
+    private getConversationUpdateHandler(bot: builder.UniversalBot): (event: builder.IConversationUpdate) => void {
+        return async function(event: builder.IConversationUpdate): Promise<void> {
+            // We are only interested in member add events
+            if (!event.membersAdded || (event.membersAdded.length === 0)) {
+                return;
+            }
+
             let session = await loadSessionAsync(bot, event);
 
-            if (event.membersAdded && event.membersAdded[0].id && event.membersAdded[0].id.endsWith(config.get("bot.botId"))) {
-                session.send(Strings.bot_introduction); // probably only works in Teams
+            // Determine if the bot was added to the conversation
+            let lowercaseBotId = config.get("bot.botId").toLowerCase();
+            let botAdded = event.membersAdded && event.membersAdded.find(user => user.id.toLowerCase().endsWith(lowercaseBotId));
+
+            if (!event.address.conversation.isGroup) {
+                // 1:1 conversation event
+                // If the user hasn't received a first-run message YET, send a message to the user,
+                // introducing your bot and what it can do. Do NOT send this blindly, as you can receive
+                // spurious conversationUpdate events, especially if you use proactive messaging.
+
+                if (!session.userData.freSent) {
+                    session.userData.freSent = true;
+                    session.send(Strings.bot_introduction);
+                } else {
+                    // First-run message has already been sent, so skip sending it again
+                }
             } else {
-                session.send(Strings.bot_welcome_to_new_person);
+                // Team event (bot or user was added to a team)
+
+                if (botAdded) {
+                    // Bot was added to the team
+                    // Send a message to the team's channel, introducing your bot and what you can do
+                    session.send(Strings.bot_introduction);
+                } else {
+                    // Other users were added to the team
+                }
             }
         };
     }
@@ -112,7 +141,7 @@ export class Bot extends builder.UniversalBot {
             let userName = event.address.user.name;
             let body = JSON.parse(query.body);
             let msg = new builder.Message(session)
-                        .text(Strings.o365connectorcard_action_response, userName, query.actionId, JSON.stringify(body, null, 2));
+                .text(Strings.o365connectorcard_action_response, userName, query.actionId, JSON.stringify(body, null, 2));
 
             session.send(msg);
 

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -118,7 +118,7 @@ export class Bot extends builder.UniversalBot {
                 } else {
                     // First-run message has already been sent, so skip sending it again
                     // Do not remove the check for "freSent" above. Your bot can receive spurious conversationUpdate
-                    // activities from chat service, so if you always respond to all of them, you will send random 
+                    // activities from chat service, so if you always respond to all of them, you will send random
                     // welcome messages to users who have already received the welcome.
                 }
             } else {

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -1,5 +1,4 @@
 import * as builder from "botbuilder";
-import * as config from "config";
 import { RootDialog } from "./dialogs/RootDialog";
 import { SetLocaleFromTeamsSetting } from "./middleware/SetLocaleFromTeamsSetting";
 import { StripBotAtMentions } from "./middleware/StripBotAtMentions";
@@ -104,8 +103,8 @@ export class Bot extends builder.UniversalBot {
             let session = await loadSessionAsync(bot, event);
 
             // Determine if the bot was added to the conversation
-            let lowercaseBotId = config.get("bot.botId").toLowerCase();
-            let botAdded = event.membersAdded && event.membersAdded.find(user => user.id.toLowerCase().endsWith(lowercaseBotId));
+            let botId = event.address.bot.id;
+            let botAdded = event.membersAdded && event.membersAdded.find(member => (member.id === botId));
 
             if (!event.address.conversation.isGroup) {
                 // 1:1 conversation event

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -37,7 +37,7 @@ export class Bot extends builder.UniversalBot {
             new SetLocaleFromTeamsSetting(),
 
             // set on "botbuilder" (after session created)
-            new ResetBotChat(this),
+            new ResetBotChat(this),             // We recommend having this only in non-prod environments, for testing your first-run experience
             new StripBotAtMentions(),
             // new SetAADObjectId(),
             new LoadBotChannelData(this.get("channelStorage")),

--- a/src/Bot.ts
+++ b/src/Bot.ts
@@ -117,6 +117,9 @@ export class Bot extends builder.UniversalBot {
                     session.send(Strings.bot_introduction);
                 } else {
                     // First-run message has already been sent, so skip sending it again
+                    // Do not remove the check for "freSent" above. Your bot can receive spurious conversationUpdate
+                    // activities from chat service, so if you always respond to all of them, you will send random 
+                    // welcome messages to users who have already received the welcome.
                 }
             } else {
                 // Team event (bot or user was added to a team)

--- a/src/middleware/ResetBotChat.ts
+++ b/src/middleware/ResetBotChat.ts
@@ -1,0 +1,39 @@
+import * as builder from "botbuilder";
+
+// Handle requests to reset the bot chat
+export class ResetBotChat implements builder.IMiddlewareMap {
+
+    constructor(private bot: builder.UniversalBot) {
+    }
+
+    public readonly botbuilder = (session: builder.Session, next: Function): void => {
+        let message = session.message;
+        if (message &&
+            !message.address.conversation.isGroup &&    // Reset bot chat is only for 1:1 chats
+            message.text === "/resetbotchat")           // The magic command
+        {
+            // Forget everything we know about the user
+            session.userData = {};
+            session.conversationData = {};
+            session.privateConversationData = {};
+            session.save().sendBatch();
+
+            // Synthesize a conversation update event
+            // Note that this is a fake event, as Teams does not support deleting a 1:1 conversation and re-creating it
+            let conversationUpdateEvent: builder.IConversationUpdate = {
+                type: "conversationUpdate",
+                agent: message.agent,
+                source: message.source,
+                sourceEvent: message.sourceEvent,
+                user: message.user,
+                address: message.address,
+                membersAdded: [ message.address.bot ],
+            };
+            this.bot.receive(conversationUpdateEvent);
+
+            // Stop processing the original trigger message
+        } else {
+            next();
+        }
+    }
+}

--- a/src/middleware/ResetBotChat.ts
+++ b/src/middleware/ResetBotChat.ts
@@ -18,6 +18,8 @@ export class ResetBotChat implements builder.IMiddlewareMap {
             session.privateConversationData = {};
             session.save().sendBatch();
 
+            // If you need to reset the user state in other services your app uses, do it here. 
+
             // Synthesize a conversation update event
             // Note that this is a fake event, as Teams does not support deleting a 1:1 conversation and re-creating it
             let conversationUpdateEvent: builder.IConversationUpdate = {

--- a/src/middleware/ResetBotChat.ts
+++ b/src/middleware/ResetBotChat.ts
@@ -18,7 +18,7 @@ export class ResetBotChat implements builder.IMiddlewareMap {
             session.privateConversationData = {};
             session.save().sendBatch();
 
-            // If you need to reset the user state in other services your app uses, do it here. 
+            // If you need to reset the user state in other services your app uses, do it here.
 
             // Synthesize a conversation update event
             // Note that this is a fake event, as Teams does not support deleting a 1:1 conversation and re-creating it

--- a/src/middleware/SimulateResetBotChat.ts
+++ b/src/middleware/SimulateResetBotChat.ts
@@ -1,7 +1,7 @@
 import * as builder from "botbuilder";
 
-// Handle requests to reset the bot chat
-export class ResetBotChat implements builder.IMiddlewareMap {
+// Handle requests to simulate resetting the bot chat
+export class SimulateResetBotChat implements builder.IMiddlewareMap {
 
     constructor(private bot: builder.UniversalBot) {
     }
@@ -20,7 +20,7 @@ export class ResetBotChat implements builder.IMiddlewareMap {
 
             // If you need to reset the user state in other services your app uses, do it here.
 
-            // Synthesize a conversation update event
+            // Synthesize a conversation update event and send it to the bot
             // Note that this is a fake event, as Teams does not support deleting a 1:1 conversation and re-creating it
             let conversationUpdateEvent: builder.IConversationUpdate = {
                 type: "conversationUpdate",

--- a/src/middleware/SimulateResetBotChat.ts
+++ b/src/middleware/SimulateResetBotChat.ts
@@ -22,14 +22,17 @@ export class SimulateResetBotChat implements builder.IMiddlewareMap {
 
             // Synthesize a conversation update event and send it to the bot
             // Note that this is a fake event, as Teams does not support deleting a 1:1 conversation and re-creating it
-            let conversationUpdateEvent: builder.IConversationUpdate = {
+            let conversationUpdateEvent: any = {
                 type: "conversationUpdate",
                 agent: message.agent,
                 source: message.source,
                 sourceEvent: message.sourceEvent,
                 user: message.user,
                 address: message.address,
-                membersAdded: [ message.address.bot ],
+                timestamp: message.timestamp,
+                localTimestamp: message.localTimestamp,
+                entities: message.entities,
+                membersAdded: [ message.address.user, message.address.bot ],
             };
             this.bot.receive(conversationUpdateEvent);
 

--- a/src/middleware/SimulateResetBotChat.ts
+++ b/src/middleware/SimulateResetBotChat.ts
@@ -30,8 +30,6 @@ export class SimulateResetBotChat implements builder.IMiddlewareMap {
                 user: message.user,
                 address: message.address,
                 timestamp: message.timestamp,
-                localTimestamp: message.localTimestamp,
-                entities: message.entities,
                 membersAdded: [ message.address.user, message.address.bot ],
             };
             this.bot.receive(conversationUpdateEvent);

--- a/src/utils/DialogMatches.ts
+++ b/src/utils/DialogMatches.ts
@@ -2,7 +2,7 @@
 // tslint:disable-next-line:variable-name
 export const DialogMatches = {
     // *************************** BEGINNING OF EXAMPLES ***************************
-    ResetUserStateDialogMatch: /reset/i,
+    ResetUserStateDialogMatch: /^reset$/i,
     VSTSAPICallDialogMatch: /vsts api call/i,
     VSTS_Auth_Validate_User_Dialog_Intent: "VSTS_Auth_Validate_User_Dialog_Intent",
     VSTSLogInDialogMatch: /log ?in/i,


### PR DESCRIPTION
- Detect condition where bot is added to 1:1 or team
- Check for previous welcome message before sending welcome to 1:1 chat
- Implement /resetbotchat to **simulate** a new conversation. Teams does not support re-creating a 1:1 chat, so the recommended approach is to simulate it.